### PR TITLE
Update fromcd.sh

### DIFF
--- a/fromcd.sh
+++ b/fromcd.sh
@@ -193,7 +193,7 @@ add_chapter_metadata () {
         title=${title//"Ch "}
         title=${title// - /. }
         title=${title//: /. }
-        title=$(sed -E 's|([0-9]{2})[a-zA-Z](.*)$|\1\2|g' <<< "$title")
+        title=$(sed -E 's|([0-9]{1,2})[a-zA-Z](.*)$|\1\2|g' <<< "$title")
         title=$(sed -E 's|0([1-9])(.*)$|\1\2|' <<< "$title")
 
         duration=$(echo "$duration + $ch_duration"  | bc);


### PR DESCRIPTION
Added Detection of single digits in the the Title Metadata for Chapters
Will now properly match both "Chapter 1b -Title" and "Chapter 01c - Title"