### PR TITLE
Update fromcd.sh

### DIFF
--- a/fromcd.sh
+++ b/fromcd.sh
@@ -253,7 +253,8 @@ join_all_m4a () {
     fn=${album// /}
     joined="${fn}.m4a"
     output="${fn}.m4b"
-    ls *.m4a | awk -F':' '{ print "file "$1 }' | ffmpeg -f concat -safe 0 -protocol_whitelist "file,http,https,tcp,tls,pipe" -i - -c copy $joined
+    ls *.m4a | perl -ne 'print "file $_"' > TRACKLIST.txt
+    ffmpeg -f concat -i TRACKLIST.txt -c copy $joined
     ffmpeg -i $joined -i $meta -map_metadata 1 -codec copy $output;
     rm $joined;
 }


### PR DESCRIPTION
Fixes an issue with some OS updates and ffmpeg concat

This fix creates a text file with a list of all files before joining
Old version did it on the fly - but in some situations ffmpeg would mis-read the file causing the script to fail.